### PR TITLE
feat: add live projects section

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta
     name="description"
-    content="Matěj Teplý is an AI/ML engineer and backend developer building practical AI systems, APIs, and automation."
+    content="Matěj Teplý is a full-stack AI/ML engineer and backend developer building practical AI systems, APIs, and automation."
   >
   <meta name="theme-color" content="#ffffff">
-  <title>Matěj Teplý — AI/ML Engineer &amp; Backend Developer</title>
+  <title>Matěj Teplý — Full-stack AI/ML Engineer &amp; Backend Developer</title>
   <link rel="stylesheet" href="styles.css">
   <link rel="icon" href="media/icon.svg" type="image/svg+xml">
   <script>
@@ -27,6 +27,7 @@
         : systemTheme;
   </script>
   <script src="menu.js" defer></script>
+  <script src="projects.js" defer></script>
 </head>
 <body>
   <a class="skip-link" href="#main-content">Skip to content</a>
@@ -48,6 +49,7 @@
       <a href="#about">About</a>
       <a href="#experience">Experience</a>
       <a href="#skills">Skills</a>
+      <a href="#projects">Projects</a>
       <a href="#contact">Contact</a>
     </nav>
 
@@ -65,8 +67,9 @@
   <main id="main-content">
     <section id="top" class="hero layout" aria-labelledby="hero-title">
       <div class="hero-copy" data-reveal>
-        <h1 id="hero-title">
-          AI/ML Engineer
+        <h1 id="hero-title" class="hero-title-long">
+          Full-stack AI/ML
+          <span class="hero-title-break">Engineer</span>
           <span class="hero-title-break">&amp; Backend Developer</span>
         </h1>
         <p class="intro">
@@ -84,7 +87,7 @@
           alt="Portrait of Matěj Teplý"
           decoding="async"
         >
-        <div class="meta-row" aria-label="Location and company">
+        <div class="meta-row" role="group" aria-label="Location and company">
           <span>Greater Zlín Area</span>
           <span>OKsystem</span>
         </div>
@@ -206,6 +209,37 @@
       </div>
     </section>
 
+    <section
+      id="projects"
+      class="section projects"
+      aria-labelledby="projects-title"
+    >
+      <header class="projects-heading" data-reveal>
+        <h2 id="projects-title">Projects</h2>
+        <p class="projects-source">
+          <span>github.com/Majkey25/*</span>
+        </p>
+      </header>
+      <p
+        id="projects-status"
+        class="projects-status"
+        role="status"
+        aria-live="polite"
+      >
+        <a
+          href="https://github.com/Majkey25?tab=repositories"
+          target="_blank"
+          rel="noopener noreferrer"
+        >View public repositories on GitHub.</a>
+      </p>
+      <ol
+        id="projects-list"
+        class="projects-list"
+        aria-label="Public repositories"
+        aria-busy="true"
+      ></ol>
+    </section>
+
     <section class="section education" aria-labelledby="education-title">
       <h2 id="education-title" data-reveal>Education</h2>
       <div class="education-list">
@@ -260,6 +294,10 @@
         <p>For professional conversations, collaboration, or a good technical problem.</p>
       </div>
       <div class="contact-links" data-reveal>
+        <a
+          class="contact-email"
+          href="mailto:majkeylab@gmail.com"
+        >majkeylab@gmail.com</a>
         <a
           href="https://www.linkedin.com/in/matejteply/"
           target="_blank"

--- a/projects.js
+++ b/projects.js
@@ -1,0 +1,125 @@
+(function () {
+  const list = document.getElementById('projects-list');
+  const status = document.getElementById('projects-status');
+
+  if (!list || !status) return;
+
+  status.textContent = 'Loading public repositories…';
+
+  const apiUrl = new URL('https://api.github.com/users/Majkey25/repos');
+  apiUrl.search = new URLSearchParams({
+    type: 'owner',
+    sort: 'full_name',
+    direction: 'asc',
+    per_page: '100'
+  });
+
+  function getNextPage(linkHeader) {
+    const nextLink = linkHeader
+      ?.split(',')
+      .find((link) => link.includes('rel="next"'));
+    return nextLink?.match(/<([^>]+)>/)?.[1] || null;
+  }
+
+  async function fetchRepositories() {
+    const repositories = [];
+    let nextPage = apiUrl.href;
+
+    while (nextPage) {
+      const response = await fetch(nextPage, {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2026-03-10'
+        }
+      });
+
+      if (!response.ok) {
+        throw new Error(`GitHub API returned ${response.status}`);
+      }
+
+      const page = await response.json();
+      if (!Array.isArray(page)) {
+        throw new TypeError('GitHub API returned an invalid response');
+      }
+
+      repositories.push(...page);
+      nextPage = getNextPage(response.headers.get('link'));
+    }
+
+    return repositories;
+  }
+
+  function createProject(repository, index) {
+    if (
+      typeof repository?.name !== 'string'
+      || typeof repository.html_url !== 'string'
+      || !repository.html_url.startsWith('https://github.com/')
+    ) {
+      return null;
+    }
+
+    const item = document.createElement('li');
+    const link = document.createElement('a');
+    const number = document.createElement('span');
+    const copy = document.createElement('span');
+    const name = document.createElement('h3');
+    const metadata = document.createElement('span');
+    const arrow = document.createElement('span');
+
+    item.className = 'project-item';
+    link.className = 'project-link';
+    link.href = repository.html_url;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    number.className = 'project-number';
+    number.textContent = String(index + 1).padStart(2, '0');
+    copy.className = 'project-copy';
+    name.className = 'project-name';
+    name.textContent = repository.name;
+    metadata.className = 'project-metadata';
+    metadata.textContent = [
+      typeof repository.language === 'string' ? repository.language : null,
+      repository.fork === true ? 'Fork' : null,
+      repository.archived === true ? 'Archived' : null
+    ].filter(Boolean).join(' · ');
+    arrow.className = 'project-arrow';
+    arrow.textContent = '↗';
+    arrow.setAttribute('aria-hidden', 'true');
+
+    copy.append(name);
+    if (typeof repository.description === 'string' && repository.description) {
+      const description = document.createElement('span');
+      description.className = 'project-description';
+      description.textContent = repository.description;
+      copy.append(description);
+    }
+
+    link.append(number, copy, metadata, arrow);
+    item.append(link);
+    return item;
+  }
+
+  function showError() {
+    const fallback = document.createElement('a');
+    fallback.href = 'https://github.com/Majkey25?tab=repositories';
+    fallback.target = '_blank';
+    fallback.rel = 'noopener noreferrer';
+    fallback.textContent = 'View them on GitHub.';
+    status.textContent = 'Projects could not load right now. ';
+    status.append(fallback);
+  }
+
+  fetchRepositories()
+    .then((repositories) => {
+      const projects = repositories
+        .map((repository, index) => createProject(repository, index))
+        .filter(Boolean);
+
+      list.replaceChildren(...projects);
+      status.textContent = projects.length === 0
+        ? 'No public repositories yet.'
+        : `${projects.length} public repositories`;
+    })
+    .catch(showError)
+    .finally(() => list.setAttribute('aria-busy', 'false'));
+})();

--- a/styles.css
+++ b/styles.css
@@ -247,6 +247,10 @@ h1 {
   font-size: clamp(2.6rem, 4vw, 3.8rem);
 }
 
+.hero-title-long {
+  font-size: clamp(2.2rem, 3.7vw, 3.45rem);
+}
+
 h2 {
   margin-bottom: 0;
   font-size: clamp(2.5rem, 4.5vw, 4.6rem);
@@ -425,6 +429,134 @@ h3 {
   font-size: 1.1rem;
 }
 
+.projects-heading {
+  margin-bottom: clamp(48px, 7vw, 90px);
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 40px;
+}
+
+.projects-source,
+.project-number,
+.project-metadata {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+}
+
+.projects-source {
+  margin: 0 0 0.55rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.projects-source span {
+  display: inline-block;
+  white-space: nowrap;
+}
+
+.motion-ready .projects-source span {
+  box-sizing: content-box;
+  width: 0;
+  overflow: hidden;
+  border-right: 1px solid currentColor;
+  animation: project-type 1.35s steps(21, end) 180ms forwards,
+    project-caret 600ms step-end 3;
+  animation-play-state: paused;
+}
+
+.motion-ready .projects-heading.is-visible .projects-source span {
+  animation-play-state: running;
+}
+
+@keyframes project-type {
+  to {
+    width: 21ch;
+  }
+}
+
+@keyframes project-caret {
+  50% {
+    border-color: transparent;
+  }
+}
+
+.projects-status {
+  margin: 0 0 18px;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.projects-status a {
+  color: var(--text);
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.projects-list {
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--strong-line);
+  list-style: none;
+}
+
+.project-item {
+  border-bottom: 1px solid var(--line);
+}
+
+.project-link {
+  padding: 30px 0;
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr) auto 24px;
+  align-items: center;
+  gap: 28px;
+}
+
+.project-number,
+.project-metadata {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.project-copy {
+  min-width: 0;
+}
+
+.project-name {
+  margin: 0;
+  font-size: clamp(1.25rem, 2vw, 1.7rem);
+  overflow-wrap: anywhere;
+}
+
+.project-description {
+  max-width: 760px;
+  margin-top: 8px;
+  display: block;
+  color: var(--muted);
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.project-metadata {
+  white-space: nowrap;
+}
+
+.project-arrow {
+  font-size: 1.25rem;
+  transition: transform 220ms var(--ease-out);
+}
+
+.project-link:hover .project-name,
+.project-link:focus-visible .project-name {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 6px;
+}
+
+.project-link:hover .project-arrow,
+.project-link:focus-visible .project-arrow {
+  transform: translate(3px, -3px);
+}
+
 .education {
   display: grid;
   grid-template-columns: 0.65fr 1.35fr;
@@ -498,6 +630,10 @@ h3 {
   text-align: center;
   transition: background-color 220ms ease, color 220ms ease,
     transform 220ms var(--ease-out);
+}
+
+.contact-links .contact-email {
+  flex-basis: 100%;
 }
 
 footer {
@@ -813,6 +949,28 @@ button:not(.theme-toggle, .menu-toggle) {
     border-left: 0;
   }
 
+  .projects-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 18px;
+  }
+
+  .project-link {
+    grid-template-columns: 34px minmax(0, 1fr) 20px;
+    align-items: start;
+    gap: 10px 18px;
+  }
+
+  .project-metadata {
+    grid-column: 2;
+    white-space: normal;
+  }
+
+  .project-arrow {
+    grid-column: 3;
+    grid-row: 1;
+  }
+
   .contact {
     min-height: 380px;
     grid-template-columns: 1fr;
@@ -919,5 +1077,11 @@ button:not(.theme-toggle, .menu-toggle) {
     transition-duration: 0.01ms !important;
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
+  }
+
+  .projects-source span {
+    width: auto;
+    border-right: 0;
+    animation: none;
   }
 }


### PR DESCRIPTION
## Summary

- load every public owned repository from the GitHub API with pagination
- add a minimal monochrome, responsive project index and reduced-motion-safe typing effect
- update the hero title and add `majkeylab@gmail.com` to Contact
- provide loading, empty, failure, and no-JavaScript fallbacks

## Verification

- live browser check: 20 repositories on desktop and mobile
- no horizontal overflow at 1440px or 390px
- GitHub pagination, empty, failure, long-text, and no-JavaScript states verified
- `node --check projects.js`
- W3C HTML validation: 0 messages
- `git diff --check`