### PR TITLE
fix(ui): match Gmail button to other contact links, improve phone usability

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -668,10 +668,6 @@ h3 {
     transform 220ms var(--ease-out);
 }
 
-.contact-links .contact-email {
-  flex-basis: 100%;
-}
-
 footer {
   padding: 30px 44px 44px;
 }
@@ -856,6 +852,7 @@ button:not(.theme-toggle, .menu-toggle) {
   background: var(--surface);
   border: 1px solid var(--line);
   cursor: crosshair;
+  touch-action: none;
 }
 
 .sketch-controls {
@@ -929,6 +926,7 @@ button:not(.theme-toggle, .menu-toggle) {
 
   .menu-toggle {
     display: block;
+    padding: 10px 4px;
   }
 
   .theme-toggle {
@@ -1035,9 +1033,9 @@ button:not(.theme-toggle, .menu-toggle) {
 
   .nav-bar #menu-toggle {
     display: block;
-    width: 40px;
-    height: 40px;
-    padding: 9px;
+    width: 44px;
+    height: 44px;
+    padding: 11px;
     border: 0;
     background: transparent;
     color: var(--text);
@@ -1057,6 +1055,18 @@ button:not(.theme-toggle, .menu-toggle) {
     padding: 16px;
     background: var(--background);
     border-bottom: 1px solid var(--line);
+  }
+
+  body > nav.open .nav-links a {
+    display: block;
+    padding: 11px 0;
+  }
+}
+
+@media (pointer: coarse) {
+  button:not(.theme-toggle, .menu-toggle),
+  .game input {
+    min-height: 44px;
   }
 }
 


### PR DESCRIPTION
## What

- **Gmail button** — dropped `.contact-links .contact-email { flex-basis: 100% }`. It forced Gmail onto its own full-width row while LinkedIn/GitHub/X/Instagram sat inline. Gmail is now styled and sized exactly like the others.
- **Sketch pad on touch** — `touch-action: none` on `#sketch-canvas`. Dragging a finger scrolled the page instead of drawing.
- **Tap targets** — 44px minimum for the sub-page hamburger, the sub-page dropdown nav links, the home page `Menu` button, and the games buttons/input on coarse pointers.

## Verification

Rendered every page (`index`, `songs`, `games`, `sketch`, `time`) in Chromium under Pixel 7 emulation (412px, DPR 2.6, touch):

- No horizontal overflow anywhere — `scrollWidth == clientWidth == 412` on all five pages.
- Contact links stack full-width and identical on phone; inline and identical at 1440px.
- Games buttons and hamburger now clear 44px.

Existing responsive rules (nav collapse, single-column grids, stacked project list) already worked and were left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)