### PR TITLE
feat(contact): Gmail button copies the address instead of opening a mail client

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,10 +382,12 @@
         <p>For professional conversations, collaboration, or a good technical problem.</p>
       </div>
       <div class="contact-links" data-reveal>
-        <a
+        <button
           class="contact-email"
-          href="mailto:majkeylab@gmail.com"
-        >Gmail</a>
+          type="button"
+          data-copy-email="majkeylab@gmail.com"
+          aria-live="polite"
+        >Gmail</button>
         <a
           href="https://www.linkedin.com/in/matejteply/"
           target="_blank"

--- a/menu.js
+++ b/menu.js
@@ -146,5 +146,50 @@ if ('IntersectionObserver' in window && navigationLinks.length > 0) {
   observedSections.forEach((section) => sectionObserver.observe(section));
 }
 
+const emailButton = document.querySelector('[data-copy-email]');
+
+if (emailButton) {
+  const defaultLabel = emailButton.textContent;
+  const SPARK_COUNT = 10;
+  let resetTimer = 0;
+
+  const sparkle = () => {
+    if (reducedMotion.matches) return;
+    for (let index = 0; index < SPARK_COUNT; index += 1) {
+      const spark = document.createElement('span');
+      spark.className = 'spark';
+      const angle = (index / SPARK_COUNT) * 2 * Math.PI;
+      const distance = 26 + Math.random() * 18;
+      spark.style.setProperty('--x', `${Math.cos(angle) * distance}px`);
+      spark.style.setProperty('--y', `${Math.sin(angle) * distance}px`);
+      spark.addEventListener('animationend', () => spark.remove());
+      emailButton.append(spark);
+    }
+  };
+
+  emailButton.addEventListener('click', async () => {
+    const email = emailButton.dataset.copyEmail;
+    let copied = false;
+    try {
+      await navigator.clipboard.writeText(email);
+      copied = true;
+    } catch {
+      // Clipboard access can be blocked; show the address so it can be copied by hand.
+    }
+
+    clearTimeout(resetTimer);
+    emailButton.textContent = copied ? 'Copied!' : email;
+    if (copied) {
+      emailButton.dataset.copied = '';
+      sparkle();
+    }
+
+    resetTimer = setTimeout(() => {
+      emailButton.textContent = defaultLabel;
+      delete emailButton.dataset.copied;
+    }, 1800);
+  });
+}
+
 const year = document.getElementById('year');
 if (year) year.textContent = String(new Date().getFullYear());

--- a/styles.css
+++ b/styles.css
@@ -342,7 +342,9 @@ h3 {
 .profile-links a:hover,
 .profile-links a:focus-visible,
 .contact-links a:hover,
-.contact-links a:focus-visible {
+.contact-links a:focus-visible,
+.contact-links .contact-email:hover,
+.contact-links .contact-email:focus-visible {
   background: var(--background);
   color: var(--text);
   transform: translateY(-2px);
@@ -654,18 +656,54 @@ h3 {
   gap: 10px;
 }
 
-.contact-links a {
+.contact-links a,
+.contact-links .contact-email {
   min-width: 112px;
   padding: 11px 16px;
   border: 1px solid var(--strong-line);
   border-radius: 0;
   background: var(--text);
   color: var(--background);
+  cursor: pointer;
   font-size: 1rem;
   font-weight: 600;
   text-align: center;
   transition: background-color 220ms ease, color 220ms ease,
     transform 220ms var(--ease-out);
+}
+
+.contact-email {
+  position: relative;
+}
+
+.contact-links .contact-email[data-copied] {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #ffffff;
+}
+
+.spark {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 6px;
+  height: 6px;
+  background: var(--accent);
+  border-radius: 50%;
+  pointer-events: none;
+  animation: spark 520ms var(--ease-out) forwards;
+}
+
+@keyframes spark {
+  from {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+
+  to {
+    opacity: 0;
+    transform: translate(calc(-50% + var(--x)), calc(-50% + var(--y))) scale(0.4);
+  }
 }
 
 footer {
@@ -1108,7 +1146,8 @@ button:not(.theme-toggle, .menu-toggle) {
     width: 100%;
   }
 
-  .contact-links a {
+  .contact-links a,
+  .contact-links .contact-email {
     width: 100%;
   }
 


### PR DESCRIPTION
## What

`mailto:` handed visitors off to Outlook (or nothing at all). The Gmail entry is now a `<button>` that:

- writes `majkeylab@gmail.com` to the clipboard
- flips its label to **Copied!** in the accent colour
- throws ten small particles outward from its centre
- returns to `Gmail` after 1.8s

If `navigator.clipboard` is blocked or unavailable, the button shows the address instead of the confirmation, so it stays readable and selectable rather than silently failing. Particles are skipped under `prefers-reduced-motion`.

The `.contact-links` rules now cover the button as well as the anchors — including the `width: 100%` rule below 520px, which previously only matched `a` and left Gmail narrower than the rest.

## Verification

Driven in headless Chromium at 412px with touch and clipboard permissions granted (`check_gmail_copy.py`):

- element is a `BUTTON` with no `href`
- `navigator.clipboard.readText()` returns `majkeylab@gmail.com` after the click
- label becomes `Copied!`, 10 `.spark` nodes spawn, and both revert — label back to `Gmail`, 0 sparks left
- all five contact links measure the same width
- no page errors

Desktop at 1440px unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)