### PR TITLE
feat(ui): title-only hover rule and a new tab icon

### DIFF
--- a/media/icon.svg
+++ b/media/icon.svg
@@ -1,20 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <defs>
-    <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#7cf0c9"/>
-      <stop offset="1" stop-color="#6ea8ff"/>
-    </linearGradient>
-    <radialGradient id="g2" cx="0.18" cy="0.2" r="0.9">
-      <stop offset="0" stop-color="#ffffff" stop-opacity=".32"/>
-      <stop offset=".7" stop-color="#0b1020" stop-opacity="0"/>
-    </radialGradient>
-  </defs>
-  <rect width="512" height="512" rx="120" fill="#050712"/>
-  <rect width="512" height="512" rx="120" fill="url(#g2)"/>
-  <rect width="512" height="512" rx="120" fill="url(#g1)" fill-opacity=".16"/>
-  <path fill="url(#g1)"
-        d="M120 366V146h66l70 112 70-112h66v220h-66V252l-66 102h-8l-66-102v114z"/>
-  <text x="256" y="418" text-anchor="middle"
-        fill="#f4f7ff" font-family="Space Grotesk, 'Segoe UI', sans-serif"
-        font-weight="700" font-size="96">25</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Matěj Teplý">
+  <rect width="512" height="512" rx="112" fill="#1646e8"/>
+  <g fill="none" stroke="#ffffff" stroke-width="42" stroke-linejoin="miter" stroke-linecap="butt">
+    <path d="M109 354V160l63 98 63-98v194"/>
+    <path d="M271 160h132"/>
+    <path d="M337 160v194"/>
+  </g>
 </svg>

--- a/styles.css
+++ b/styles.css
@@ -752,10 +752,22 @@ footer p {
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .motion-ready :is(h2, p)[data-reveal].is-visible:hover,
-  .motion-ready [data-reveal].is-visible > :is(h1, h3, p, time):hover {
-    color: var(--accent);
-    transform: translateX(6px);
+  /* Titles only, and only an accent rule wiping in under them — the same
+     gesture the nav links already use. Body copy is left alone. */
+  .motion-ready :is(h2, h3):not(.project-name) {
+    /* Both fit-content values keep the rule on the text: grid stretches these
+       headings well past their line box otherwise. */
+    width: fit-content;
+    height: fit-content;
+    background-image: linear-gradient(var(--accent), var(--accent));
+    background-repeat: no-repeat;
+    background-position: 0 100%;
+    background-size: 0 2px;
+    transition: background-size 340ms var(--ease-out);
+  }
+
+  .motion-ready :is(h2, h3):not(.project-name):hover {
+    background-size: 100% 2px;
   }
 }
 


### PR DESCRIPTION
## Hover

Before, `:is(h2, p)[data-reveal]` and `> :is(h1, h3, p, time)` all turned `var(--accent)` and slid `translateX(6px)` on hover — so paragraphs, timeline dates and job titles jumped around while you read.

Now: **section titles only** (`h2`, `h3`, excluding `.project-name`, which already has its own underline), and the gesture is an accent rule wiping in left-to-right under the title — the same motion `.site-nav a::after` already uses. No colour change, nothing moves.

`width: fit-content` and `height: fit-content` are both required — grid stretches these headings well past their line box, which left the rule floating ~70px below the text on the first attempt.

## Icon

The old `media/icon.svg` was a mint→blue gradient `M` with `25` on near-black: it matched nothing on the site's black/white palette and disappeared against a dark tab strip. Replaced with an accent-blue square and a white `MT` monogram, drawn as stroked paths so it does not depend on a font being installed. Checked at 16px, 32px and 64px on both light and dark backgrounds.

## Verification

Headless Chromium at 1440px with a fine pointer:

- heading `background-size` goes `0px 2px` → `100% 2px` on hover
- paragraph colour is `rgb(17,17,17)` before and after hover, transform stays identity
- `.project-name` has `background-image: none` — excluded as intended
- `media/icon.svg` serves 200 with SVG content
- no page errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)