### PR TITLE
feat(nav): brand mark, Education and Spare time entries, working scroll spy

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,15 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
 
   <header class="site-header">
-    <a class="brand" href="#top" aria-label="Matěj Teplý, home">Matěj Teplý</a>
+    <a class="brand" href="#top" aria-label="Matěj Teplý, home">
+      <svg class="brand-mark" viewBox="0 0 512 512" aria-hidden="true">
+        <g fill="none" stroke-linejoin="miter" stroke-linecap="butt">
+          <path d="M134 446V66l122 212L378 66v380" stroke="currentColor" stroke-width="102"/>
+          <path class="brand-mark-inline" d="M134 379V150l122 128L378 150v229" stroke-width="30"/>
+        </g>
+      </svg>
+      <span>Matěj Teplý</span>
+    </a>
 
     <button
       id="menu-toggle"
@@ -49,6 +57,8 @@
       <a href="#experience">Experience</a>
       <a href="#skills">Skills</a>
       <a href="#projects">Projects</a>
+      <a href="#education">Education</a>
+      <a href="#spare-time">Spare time</a>
       <a href="#contact">Contact</a>
     </nav>
 
@@ -328,7 +338,7 @@
       </a>
     </section>
 
-    <section class="section education" aria-labelledby="education-title">
+    <section id="education" class="section education" aria-labelledby="education-title">
       <h2 id="education-title" data-reveal>Education</h2>
       <div class="education-list">
         <article data-reveal>
@@ -348,8 +358,12 @@
       </div>
     </section>
 
-    <section class="section layout outside" aria-labelledby="outside-title">
-      <h2 id="outside-title" data-reveal>Outside work</h2>
+    <section
+      id="spare-time"
+      class="section layout outside"
+      aria-labelledby="spare-time-title"
+    >
+      <h2 id="spare-time-title" data-reveal>Spare time</h2>
       <p class="section-copy" data-reveal>
         Music is a core part of who I am, not just a side hobby.<br><br>
         I play drums, guitar, saxophone, and sing. It shapes how I think about

--- a/media/_p.html
+++ b/media/_p.html
@@ -1,0 +1,1 @@
+<body style="margin:0;background:#fff;display:flex;gap:20px;align-items:flex-end;padding:16px"><img src="icon.svg" width="16"><img src="icon.svg" width="32"><img src="icon.svg" width="64"><img src="icon.svg" width="240"></body>

--- a/media/icon.svg
+++ b/media/icon.svg
@@ -1,8 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Matěj Teplý">
-  <rect width="512" height="512" rx="112" fill="#1646e8"/>
-  <g fill="none" stroke="#ffffff" stroke-width="42" stroke-linejoin="miter" stroke-linecap="butt">
-    <path d="M109 354V160l63 98 63-98v194"/>
-    <path d="M271 160h132"/>
-    <path d="M337 160v194"/>
+  <rect width="512" height="512" fill="#ffffff"/>
+  <g fill="none" stroke-linejoin="miter" stroke-linecap="butt">
+    <path d="M134 446V66l122 212L378 66v380" stroke="#111111" stroke-width="102"/>
+    <path d="M134 379V150l122 128L378 150v229" stroke="#ffffff" stroke-width="30"/>
   </g>
 </svg>

--- a/menu.js
+++ b/menu.js
@@ -140,7 +140,10 @@ if ('IntersectionObserver' in window && navigationLinks.length > 0) {
         });
       });
     },
-    { rootMargin: '-25% 0px -65% 0px' }
+    // A 1px band across the middle of the viewport. Sections tile the page, so
+    // exactly one always crosses it — including the last one at the very bottom,
+    // which the old bottom-heavy margin could never reach.
+    { rootMargin: '-50% 0px -50% 0px' }
   );
 
   observedSections.forEach((section) => sectionObserver.observe(section));

--- a/styles.css
+++ b/styles.css
@@ -100,9 +100,23 @@ input:focus-visible {
 
 .brand {
   width: fit-content;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
   font-size: 1.2rem;
   font-weight: 700;
   letter-spacing: -0.03em;
+}
+
+.brand-mark {
+  width: 26px;
+  height: 26px;
+  flex: 0 0 auto;
+}
+
+/* Knocks the inline M out of the solid one, so the mark follows the theme. */
+.brand-mark-inline {
+  stroke: var(--background);
 }
 
 .site-nav {
@@ -960,6 +974,18 @@ button:not(.theme-toggle, .menu-toggle) {
   color: var(--text);
   font-size: var(--CLOCK_NUMBER_SIZE);
   transform: translate(-50%, -50%);
+}
+
+/* Seven links plus the brand and the theme toggle stop fitting well before the
+   hamburger takes over at 820px. */
+@media (max-width: 1040px) {
+  .site-header {
+    gap: 22px;
+  }
+
+  .site-nav {
+    gap: 20px;
+  }
 }
 
 @media (max-width: 820px) {


### PR DESCRIPTION
## Missing nav entries

`Education` and the section formerly called `Outside work` had **no `id` and no nav entry** — two sections of the page unreachable from the header. Both are linked now, and `Outside work` is renamed **Spare time** (`#spare-time`).

## Scroll spy highlighted the wrong tab

At the bottom of the page the nav said *Projects* while you were reading *Contact*.

The observer used `rootMargin: '-25% 0px -65% 0px'` — a band in the upper third of the viewport. The last section can never reach it, because the page runs out of scroll first, so the highlight stuck on whatever was last seen.

Replaced with a 1px band across the middle (`-50% 0px -50% 0px`). Sections tile the page, so exactly one always crosses the middle — including at maximum scroll.

## Header fit

Seven links stopped fitting alongside the brand and the theme toggle between 820px (where the hamburger takes over) and ~1040px. Header and nav gaps tighten in that range.

## Brand mark

The M mark is now the tab icon and sits in the top-left next to the name. The header copy is inline SVG: the solid stroke uses `currentColor` and the inline groove uses `var(--background)`, so it inverts with the theme rather than going black-on-black. (A `var()` in a presentation attribute would not have resolved — the groove colour is set from CSS.)

## Verification

Headless Chromium:

- nav links are exactly the seven section ids; the only section without an entry is `#top`
- centring each of the seven sections highlights that exact link
- pressing `End` reaches the true page bottom and the nav reads `#contact`
- no header or document overflow at 1440 / 1100 / 900 / 860 / 840 / 830 / 821px
- mark strokes are `rgb(17,17,17)` / `rgb(255,255,255)` in light and `rgb(245,245,242)` / `rgb(16,16,16)` in dark
- mobile menu at 412px lists all seven, 383px tall, no overflow
- earlier checks still pass: Gmail copy (clipboard + 10 particles), title-only hover, body copy untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)