### PR TITLE
fix(icon): round the tab icon and stop the M being clipped at the top

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
   <header class="site-header">
     <a class="brand" href="#top" aria-label="Matěj Teplý, home">
       <svg class="brand-mark" viewBox="0 0 512 512" aria-hidden="true">
-        <g fill="none" stroke-linejoin="miter" stroke-linecap="butt">
+        <g fill="none" stroke-linejoin="miter" stroke-linecap="butt" stroke-miterlimit="2.5">
           <path d="M134 446V66l122 212L378 66v380" stroke="currentColor" stroke-width="102"/>
           <path class="brand-mark-inline" d="M134 379V150l122 128L378 150v229" stroke-width="30"/>
         </g>

--- a/media/_p.html
+++ b/media/_p.html
@@ -1,1 +1,0 @@
-<body style="margin:0;background:#fff;display:flex;gap:20px;align-items:flex-end;padding:16px"><img src="icon.svg" width="16"><img src="icon.svg" width="32"><img src="icon.svg" width="64"><img src="icon.svg" width="240"></body>

--- a/media/icon.svg
+++ b/media/icon.svg
@@ -1,6 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Matěj Teplý">
-  <rect width="512" height="512" fill="#ffffff"/>
-  <g fill="none" stroke-linejoin="miter" stroke-linecap="butt">
+  <rect width="512" height="512" rx="112" fill="#ffffff"/>
+  <g
+    fill="none"
+    stroke-linejoin="miter"
+    stroke-linecap="butt"
+    stroke-miterlimit="2.5"
+    transform="translate(256 256) scale(0.84) translate(-256 -256)"
+  >
     <path d="M134 446V66l122 212L378 66v380" stroke="#111111" stroke-width="102"/>
     <path d="M134 379V150l122 128L378 150v229" stroke="#ffffff" stroke-width="30"/>
   </g>


### PR DESCRIPTION
## The clipping

The M looked cut off at the top of the tab. It was not a padding problem.

Where each stem meets its diagonal the path turns through ~150°, giving a miter ratio of **3.9** — just under the default `stroke-miterlimit` of 4, so Chromium drew the joins as **two ~200-unit spikes shooting up past the edge of the viewBox**. What read as a flat-topped M was actually the canvas cropping those spikes.

`stroke-miterlimit="2.5"` bevels those two joins (3.9 > 2.5) while leaving the middle V mitred to a point, since that join only needs a ratio of 2.0. The bevelled corners also match the reference artwork more closely than a flat top does.

## Rounding and fit

- `rx="112"` on the icon square, matching the radius the downloader icon already uses.
- With the spikes gone the mark's true stroked extent is **346 × 380**, measured in the browser rather than guessed. It scales to `0.84` and lands at x 110–402, y 96–416 — inside the 96-unit padding the rounded corners need.

The header copy of the mark had the identical clipping and gets the same `stroke-miterlimit`.

Also deletes `media/_p.html`, a scratch preview file I committed by accident in the previous PR.

## Verification

- Rendered at 16 / 32 / 64 / 200px on both light and dark backgrounds: fully inside the rounded square, no clipping, legible at 16px
- Nav checks still pass: seven links, correct highlight for every section including the page bottom, no overflow at 1440 → 821px
- Header mark still inverts with the theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)